### PR TITLE
Static build workarounds for EUI

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,5 @@
 module.exports = {
-  module.exports = {
-    pathPrefix: "/gatsby-kibana-starter",
-  },
+  pathPrefix: "/gatsby-kibana-starter",
   siteMetadata: {
     title: `Gatsby Kibana Starter`,
     description: `Start building Kibana protoypes quickly with the Gatsby Kibana Starter`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,4 +4,29 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
 
-// You can delete this file if you're not using it
+exports.onCreateWebpackConfig = ({
+  stage,
+  rules,
+  loaders,
+  plugins,
+  actions,
+}) => {
+  if (stage === "build-html") {
+    actions.setWebpackConfig({
+      module: {
+        rules: [
+          {
+            test: /react-ace/,
+            use: loaders.null(),
+          },
+        ],
+      },
+      plugins: [
+        plugins.define({
+          HTMLElement: {},
+          window: {},
+        }),
+      ],
+    })
+  }
+}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -7,6 +7,7 @@
 
 import React from "react"
 
+import "../styles/index.scss"
 import "./layout.scss"
 
 import {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,4 +1,5 @@
-import React, { Fragment, Link } from "react"
+import React, { Fragment } from "react"
+import { Link } from "gatsby"
 
 import Layout from "../components/layout";
 import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React from "react"
 import { Link } from "gatsby"
 
-import "../styles/index.scss"
 import Layout from "../components/layout"
 import {
   EuiPage,


### PR DESCRIPTION
Adds webpack definition and loader workarounds to allow static html builds. EUI will _eventually_ take care of these things on its own, but for now we can hack the shortcomings.
Also, misc. layout fixes including a single, global style import and `Link` import correction